### PR TITLE
fixed mkdir with arg provided

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -89,12 +89,14 @@ int acceptInput(){
                     mkdirName[strcspn(mkdirName, "\n")] = '\0';
                     //create directory from name entered
                     makedir(mkdirName);
+                }else{
+                    fprintf(stderr, "Error reading directory name.\n");
                 }
-                else{
+            }
+            else{
                     // if arguments are passed, create directory with argument as directory name
                     makedir(args);
                 }
-            }
         }
 
         return 0;


### PR DESCRIPTION
This pull request includes a small change to the `acceptInput` function in the `shell.c` file. The change adds an error message to handle cases where reading the directory name fails.

* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834R92-L98): Added an error message to handle cases where reading the directory name fails in the `acceptInput` function.