### PR TITLE
added command history using readline

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -1,13 +1,16 @@
-# include <stdio.h>
-# include <unistd.h>
-# include <string.h>
-# include <dirent.h>
-# include <stdbool.h>
-# include <stdlib.h>
-# include <sys/wait.h>
-# include <sys/stat.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <dirent.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <readline/readline.h>
+#include <readline/history.h>
 
-# define MAX_CHAR_LENGTH 1024
+#define MAX_CHAR_LENGTH 1024
+#define MAX_HISTORY 100
 
 // define an enum that will be used in switch statement based on commands entered
 typedef enum {
@@ -18,66 +21,71 @@ typedef enum {
 
 int processInput();
 void prompt();
-void listDir(char *path);
 void changeDir(char *path);
-void makedir(char *dirname);
 void parseInput(char *input, char **command, char **args);
 void externalCommand(char *command, char *args);
 CommandType getCommandType(char *command);
 
-
 // function to parse the input into commands and arguments
 void parseInput(char *input, char **command, char **args){
     // parse the command from the input string
-    *command = strtok(input, " "); 
-    //parse the arguments from the input string
+    *command = strtok(input, " ");
+    // parse the arguments from the input string
     *args = strtok(NULL, "");
 }
 
 // create a function that returns an enum based on command entered to use in switch
 CommandType getCommandType(char *command){
-    if(strcmp(command, "cd") == 0){ return CMD_CD; }
-    else if(strcmp(command, "exit") == 0){return CMD_EXIT; }
-    else { return CMD_UNKNOWN; }
+    if (strcmp(command, "cd") == 0){
+        return CMD_CD;
+    }
+    else if (strcmp(command, "exit") == 0){
+        return CMD_EXIT;
+    }
+    else{
+        return CMD_UNKNOWN;
+    }
 }
 
 // function to allow user input that can be processed
 int processInput(){
 
-    char user_input[MAX_CHAR_LENGTH];
+    // set the cwd variable to the maximum size
+    char cwd[1024];
+    char prompt_str[MAX_CHAR_LENGTH];
+    // get cwd
+    getcwd(cwd, sizeof(cwd));
 
-   // Use fgets to read input
-    if (fgets(user_input, sizeof(user_input), stdin) != NULL) {
+    snprintf(prompt_str, sizeof(prompt_str), "\033[32m%s>\033[0m ", cwd);
+
+
+    // use readline to handle user input
+    char *user_input = readline(prompt_str);
 
         // Remove newline character if present at the end of the input
         user_input[strcspn(user_input, "\n")] = '\0';
-
+        add_history(user_input);
         // create pointer to command and args
         char *command = NULL;
         char *args = NULL;
         parseInput(user_input, &command, &args);
-
         CommandType cmdType = getCommandType(command);
 
         switch (cmdType){
-
-            case(CMD_EXIT):
+            case (CMD_EXIT):
                 exit(0);
                 return 0;
                 break;
             
             case (CMD_CD):
-
-                if(args == NULL || strlen(args) == 0){
-
+                if (args == NULL || strlen(args) == 0){
                     char *home = getenv("HOME");
-                    //change directory
+                    // change directory
                     changeDir(home);
                 }
-                else {
+                else{
                     changeDir(args);
                 }
-
                 break;
 
             case (CMD_UNKNOWN):
@@ -86,40 +94,39 @@ int processInput(){
                 externalCommand(command, args);
                 break;
         }
-
         return 0;
-
-    } else {
-        // Handle input errors
-        perror("Error reading user input");
-        return 1;
     }
-}
+    // else{
+    //     // Handle input errors
+    //     perror("Error reading user input");
+    //     return 1;
+    // }
+// }
 
 // function to handle any external commands entered
-void externalCommand(char *command, char *args){
-
+void externalCommand(char *command, char *args)
+{
     pid_t pid = fork();
-
-    if(pid == -1){
+    if (pid == -1){
         perror("fork");
     }
-    else if(pid == 0){
-        //create an array to store the arguments
+    else if (pid == 0){
+        // create an array to store the arguments
         char *argv[MAX_CHAR_LENGTH];
 
-        //the first element of the array is the command
+        // the first element of the array is the command
         argv[0] = command;
 
         // if there were arguments entered
-        if(args != NULL){
+        if (args != NULL){
             // create variable to hold arguments by seperating arguments entered by spaces between them
             char *token = strtok(args, " ");
 
             int i = 1;
             // iterate through the arguments passed
-            while (token != NULL){
-                //store each argument(token) in the argument array(argv)
+            while (token != NULL)
+            {
+                // store each argument(token) in the argument array(argv)
                 argv[i++] = token;
                 // return the next argument/token from the string entered
                 token = strtok(NULL, " ");
@@ -131,20 +138,19 @@ void externalCommand(char *command, char *args){
             argv[1] = NULL;
         }
 
-        //execute the command and arguments passed
-            execvp(command, argv);
+        // execute the command and arguments passed
+        execvp(command, argv);
 
-            // If execvp returns, it means the command failed
-            perror("execvp");
-            exit(EXIT_FAILURE);
+        // If execvp returns, it means the command failed
+        perror("execvp");
+        exit(EXIT_FAILURE);
     }
-    
+
     else{
 
-            int status;
-            waitpid(pid, &status, 0);
-        }
-
+        int status;
+        waitpid(pid, &status, 0);
+    }
 }
 
 // function to show the current directory as a prompt
@@ -152,10 +158,10 @@ void prompt(){
 
     // set the cwd variable to the maximum size
     char cwd[1024];
-    //get cwd
+    // get cwd
     getcwd(cwd, sizeof(cwd));
 
-    //print out cwd to console
+    // print out cwd to console
     printf("\033[32m%s \033[0m> ", cwd);
 
     processInput();
@@ -169,8 +175,8 @@ void changeDir(char *path){
 // main function
 int main(){
 
-    do {
-        prompt();
+    do{
+        processInput();
     } while (1);
 
     return 0;


### PR DESCRIPTION
This pull request includes several changes to the `shell.c` file to improve user input handling and code readability. The most important changes include adding the `readline` and `history` libraries, modifying the `processInput` function to use `readline`, and refactoring the code for better readability.

Improvements to user input handling:

* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834R9-R13): Added `readline` and `history` libraries to enhance user input functionality.
* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L39-L80): Modified the `processInput` function to use `readline` for reading user input and `add_history` to store the command in history.

Code readability enhancements:

* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L39-L80): Refactored `getCommandType` function for better readability by adding braces around conditional blocks.
* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L121-R128): Improved the structure of the `externalCommand` function by adding braces around the `while` loop.

Simplification of main loop:

* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L173-R179): Replaced the call to `prompt()` with `processInput()` in the `main` function to directly handle user input in the main loop.