### PR TITLE
updated prompt styling

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -73,9 +73,9 @@ int processInput(){
 
 
     if (strlen(branch) > 0) {
-        snprintf(prompt_str, sizeof(prompt_str), "\033[34m%s (\033[33m%s\033[34m)> \033[0m ", cwd, branch);
+        snprintf(prompt_str, sizeof(prompt_str), "\033[34m[%s](\033[33m%s\033[34m)$ \033[0m", cwd, branch);
     } else {
-        snprintf(prompt_str, sizeof(prompt_str), "\033[34m%s> \033[0m ", cwd);
+        snprintf(prompt_str, sizeof(prompt_str), "\033[34m[%s]$ \033[0m", cwd);
     }
 
 


### PR DESCRIPTION
This pull request includes a small change to the `processInput` function in the `shell.c` file. The change modifies the prompt format to use square brackets around the current working directory and branch name.

* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L76-R78): Updated the prompt format in `processInput` to use square brackets around `cwd` and `branch`.