### PR TITLE
refactored code so there isnt one huge function doing so much

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -10,7 +10,7 @@
 #include <readline/history.h>
 
 #define MAX_CHAR_LENGTH 1024
-#define MAX_ALIASES 50
+#define MAX_ALIASES 100
 #define MAX_ALIAS_NAME 50
 #define MAX_ALIAS_VALUE 1024
 
@@ -35,7 +35,7 @@ Alias aliases[MAX_ALIASES];
 int alias_count = 0;
 
 int processInput();
-void prompt();
+char *buildPrompt();
 void changeDir(char *path);
 void parseInput(char *input, char **command, char **args);
 void externalCommand(char *command, char *args);
@@ -139,9 +139,11 @@ void parseInput(char *input, char **command, char **args)
     *args = strtok(NULL, "");
 }
 
-// function to allow user input that can be processed
-int processInput()
+// create function that will build a prompt string
+char *buildPrompt()
 {
+
+    static char prompt_str[MAX_CHAR_LENGTH];
 
     // set the cwd variable to the maximum size
     char cwd[1024];
@@ -159,8 +161,6 @@ int processInput()
         pclose(fp);
     }
 
-    // create variable used to build prompt string
-    char prompt_str[MAX_CHAR_LENGTH];
     // get cwd
     getcwd(cwd, sizeof(cwd));
 
@@ -173,6 +173,16 @@ int processInput()
     {
         snprintf(prompt_str, sizeof(prompt_str), "\033[34m[%s]$ \033[0m", cwd);
     }
+
+    return prompt_str;
+}
+
+// function to allow user input that can be processed
+int processInput()
+{
+
+    // create pointer to built prompt string
+    char *prompt_str = buildPrompt();
 
     // use readline to handle user input
     char *user_input = readline(prompt_str);
@@ -188,9 +198,13 @@ int processInput()
 
     // Check if the command is an alias
     char *aliasValue = getAlias(command);
+
+    // if command has an alias
     if (aliasValue != NULL)
     {
         char expandedCommand[MAX_CHAR_LENGTH];
+
+        // if arguments entered with alias, break up alias into command and args
         if (args != NULL)
         {
             snprintf(expandedCommand, sizeof(expandedCommand), "%s %s", aliasValue, args);


### PR DESCRIPTION
This pull request includes several changes to the `shell.c` file to improve the handling of prompts and aliases. The most important changes include increasing the maximum number of aliases, refactoring the prompt building process, and enhancing the alias handling logic.

### Enhancements to prompt handling:

* Increased the maximum number of aliases from 50 to 100. (`shell.c` [shell.cL13-R13](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L13-R13))
* Refactored the `prompt` function to `buildPrompt` to create a prompt string and return it. (`shell.c` [[1]](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L38-R38) [[2]](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L142-R147) [[3]](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L162-L163) [[4]](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834R177-R186)

### Improvements to alias handling:

* Enhanced the `processInput` function to better handle aliases by checking if the command has an alias and expanding it with arguments if present. (`shell.c` [shell.cR201-R207](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834R201-R207))