### PR TITLE
changed alias logic so that shell session aliases arent added to .jsh…

### DIFF
--- a/shell.c
+++ b/shell.c
@@ -78,10 +78,10 @@ void loadConfig(){
     // handle case of no .jshrc file
     if (file == NULL)
     {
-        fprintf(stderr, "No .jshrc file found in %s.\n", location);
+        fprintf(stderr, "\033[31mNo .jshrc file found in %s.\n", location);
         file = fopen(location, "w");
 
-        printf("Creating .jshrc file in your home directory...\n");
+        printf("\033[33mCreating .jshrc file in your home directory...\n\033[0m");
         fprintf(file, "# This is your jsh config file. Enter aliases here.\n# Example:\n");
         // enter an example alias 
         fprintf(file, "alias ll='ls -al'\n");
@@ -179,24 +179,6 @@ void addAlias(char *name, char *value)
 
         // print a message stating that alias was created
         //printf("Alias %s='%s' created.\n", aliases[alias_count].name, aliases[alias_count].value);
-
-        // get the home directory location
-        char *home = getenv("HOME");
-
-        char location[MAX_CHAR_LENGTH];
-
-        snprintf(location, sizeof(location), "%s/.jshrc", home);
-
-        FILE *file = fopen(location, "a");
-        if (file)
-        {
-            fprintf(file, "alias %s='%s'\n", name, aliases[alias_count].value);
-            fclose(file);
-        }
-        else
-        {
-            fprintf(stderr, "Error: Could not open .jshrc for writing.\n");
-        }
 
         alias_count++;
     }


### PR DESCRIPTION
This pull request includes changes to the `shell.c` file to enhance the user experience by adding color to the output messages and removing redundant code in the alias creation function.

Enhancements to user experience:

* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L81-R84): Added ANSI color codes to the error message when no `.jshrc` file is found and to the message indicating the creation of the `.jshrc` file. This improves the visibility of important messages to the user.

Code simplification:

* [`shell.c`](diffhunk://#diff-14b566f3da0fbeec3971e06340d39bee06be85ea1971365c2d6792d82ea85834L183-L200): Removed redundant code in the `addAlias` function that attempted to write new aliases to the `.jshrc` file. This code was unnecessary and has been cleaned up to streamline the function.…rc anymore